### PR TITLE
Fix Null Tokens Bug 

### DIFF
--- a/scripts/cartScript.js
+++ b/scripts/cartScript.js
@@ -1,3 +1,5 @@
+checkSavedCartFeature();
+
 const cartContainer = document.getElementById('cart_items');
 
 var prodMatrix = [

--- a/scripts/cartScript.js
+++ b/scripts/cartScript.js
@@ -197,6 +197,7 @@ function checkSavedCartFeature()
     }
     else
     {
+        sessionStorage.setItem("Tokens", 0);
         return false;
     }
 }


### PR DESCRIPTION
# Fix Null Tokens Displaying on Cart Page

Since the number of tokens had initially been displayed only to users with an account, an amount had not been allocated for guest users. Consequently, the cart page was displaying "null" tokens for guest users. This branch fixes this issue and displays 0 tokens for guest users as opposed to "null". 

![CartNullTokens](https://github.com/bryanltran/SpreeForFree/assets/111696697/0a3620ad-2463-4706-ad17-d5bbc5b9a060)
